### PR TITLE
feat(skill): add slidev-migrate Claude Code skill

### DIFF
--- a/.changeset/vitest-setup-and-script-rename.md
+++ b/.changeset/vitest-setup-and-script-rename.md
@@ -1,0 +1,5 @@
+---
+"slidev-workspace": patch
+---
+
+Add Vitest unit test configuration with `src/preview` alias, add unit tests for `normalizeCategories`, and rename `dev:preview` script to `dev:watch` for clarity.

--- a/.claude/skills/slidev-migrate/SKILL.md
+++ b/.claude/skills/slidev-migrate/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: slidev-migrate
+description: Migrate a single Slidev project into a Slidev workspace structure. Use when the user wants to convert an existing single Slidev project (slides.md + package.json) into a multi-presentation workspace managed by slidev-workspace. Triggers on phrases like "migrate to workspace", "convert to workspace", "set up slidev workspace", "move my slidev to workspace", or any request to organize multiple Slidev presentations under one workspace.
+---
+
+# slidev-migrate
+
+Migrate a single Slidev project to a `slidev-workspace` structure.
+
+## What the migration does
+
+**Before:**
+
+```
+my-talk/
+├── slides.md
+├── package.json   (@slidev/cli dependency)
+├── components/
+└── ...
+```
+
+**After:**
+
+```
+my-talk-workspace/
+├── slides/
+│   └── my-talk/          ← original project moved here
+│       ├── slides.md
+│       ├── package.json   (dev script updated with --base)
+│       └── ...
+├── package.json           ← new root (slidev-workspace scripts)
+├── pnpm-workspace.yaml
+└── slidev-workspace.yaml  ← hero/baseUrl config
+```
+
+## Automated migration (recommended)
+
+Run the migration script:
+
+```bash
+python3 .claude/skills/slidev-migrate/scripts/migrate.py \
+  --slides-dir <path-to-single-slidev-project> \
+  --workspace-name <new-workspace-folder-name> \
+  --base-url /<repo-name>
+```
+
+The script:
+
+1. Validates a Slidev project exists (`slides.md` + `@slidev/cli` in `package.json`)
+2. Creates `slides/<project-name>/` with the project files (excluding `node_modules`, `dist`, `.git`)
+3. Updates the slide's `dev` script to add `--base /<folder-name>/`
+4. Generates root `package.json`, `pnpm-workspace.yaml`, and `slidev-workspace.yaml`
+
+After running:
+
+```bash
+cd <workspace-name>
+pnpm install
+pnpm dev    # starts slidev-workspace preview
+```
+
+## Manual migration steps
+
+If the script doesn't fit (e.g., monorepo, in-place migration):
+
+1. **Move the project** into `slides/<project-name>/`
+2. **Update the dev script** in the slide's `package.json`:
+   ```json
+   "dev": "slidev --base /<project-name>/"
+   ```
+3. **Create `pnpm-workspace.yaml`** at workspace root:
+   ```yaml
+   packages:
+     - "slides/*"
+   ```
+4. **Create `slidev-workspace.yaml`** at workspace root:
+   ```yaml
+   hero:
+     title: "My Slide Collection"
+     description: "Browse all available slide decks"
+   baseUrl: "/<repo-name>"
+   ```
+5. **Create root `package.json`**:
+   ```json
+   {
+     "name": "my-workspace",
+     "private": true,
+     "type": "module",
+     "scripts": {
+       "dev": "slidev-workspace preview",
+       "build": "slidev-workspace build"
+     },
+     "devDependencies": {
+       "slidev-workspace": "latest"
+     }
+   }
+   ```
+6. Run `pnpm install` and `pnpm dev`
+
+## Adding more slides after migration
+
+Add more presentations by placing subdirectories inside `slides/`. Each needs a `slides.md` and a `package.json` with a `dev` script that includes `--base /<folder-name>/`.
+
+## Key configuration options
+
+`slidev-workspace.yaml`:
+
+- `baseUrl` — URL base path; must match GitHub repo name for GitHub Pages
+- `hero.title` / `hero.description` — workspace landing page text
+- `sidebar.title` / `sidebar.githubUrl` — sidebar branding
+- `outputDir` — build output directory (default: `./dist`)
+- `exclude` — folder names to skip
+
+## Caveats
+
+- **pnpm catalog:** If the slide's `package.json` uses `catalog:` versions, the workspace root needs a `catalog:` section in `pnpm-workspace.yaml`. Ask the user if they use pnpm catalogs.
+- **In-place migration:** If the user wants to convert the current directory (not create a parent workspace), create a `slides/` subfolder, move files in, and add the config files at the same root.
+- **Already a workspace:** If a `pnpm-workspace.yaml` or `slidev-workspace.yaml` already exists, skip workspace creation and only add/update the config files.

--- a/.claude/skills/slidev-migrate/scripts/migrate.py
+++ b/.claude/skills/slidev-migrate/scripts/migrate.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+Migrate a single Slidev project into a Slidev workspace structure.
+
+Usage:
+    python3 migrate.py [--slides-dir <path>] [--workspace-name <name>] [--base-url <url>]
+
+Arguments:
+    --slides-dir      Path to the existing single Slidev project (default: current directory)
+    --workspace-name  Name for the new workspace root directory (default: <project>-workspace)
+    --base-url        baseUrl for slidev-workspace.yaml (e.g. /my-slides)
+"""
+
+import argparse
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+
+def detect_slidev_project(path: Path) -> bool:
+    """Check if path contains a Slidev project."""
+    has_slides_md = (path / "slides.md").exists()
+    has_pkg = (path / "package.json").exists()
+    if not (has_slides_md and has_pkg):
+        return False
+    pkg = json.loads((path / "package.json").read_text())
+    deps = {**pkg.get("dependencies", {}), **pkg.get("devDependencies", {})}
+    return "@slidev/cli" in deps
+
+
+def already_workspace(path: Path) -> bool:
+    """Check if path is already a workspace root."""
+    return (path / "slidev-workspace.yaml").exists() or (path / "pnpm-workspace.yaml").exists()
+
+
+def migrate(slides_dir: Path, workspace_name: str, base_url: str):
+    slides_dir = slides_dir.resolve()
+
+    if not detect_slidev_project(slides_dir):
+        print(f"❌ No Slidev project detected at {slides_dir}")
+        print("   Expected: slides.md + package.json with @slidev/cli dependency")
+        sys.exit(1)
+
+    project_name = slides_dir.name
+    workspace_root = slides_dir.parent / workspace_name
+
+    if workspace_root.exists():
+        print(f"❌ Directory already exists: {workspace_root}")
+        print("   Remove it or choose a different --workspace-name")
+        sys.exit(1)
+
+    print(f"📁 Creating workspace: {workspace_root}")
+    workspace_root.mkdir(parents=True)
+    slides_dest = workspace_root / "slides" / project_name
+    slides_dest.parent.mkdir()
+
+    # Copy the Slidev project into slides/<project-name>/
+    print(f"📦 Moving {project_name} → slides/{project_name}/")
+    shutil.copytree(
+        slides_dir,
+        slides_dest,
+        ignore=shutil.ignore_patterns("node_modules", ".git", "dist", ".DS_Store"),
+    )
+
+    # Update the slide project's package.json dev script to include --base
+    pkg_path = slides_dest / "package.json"
+    pkg = json.loads(pkg_path.read_text())
+    scripts = pkg.get("scripts", {})
+    if "dev" in scripts:
+        import re
+        # Always set --base to the destination folder name, replacing any existing --base value
+        new_dev = re.sub(r"\s+--base\s+\S+", "", scripts["dev"]).rstrip()
+        scripts["dev"] = f"{new_dev} --base /{project_name}/"
+        pkg["scripts"] = scripts
+        pkg_path.write_text(json.dumps(pkg, indent=2, ensure_ascii=False) + "\n")
+        print(f"✏️  Updated dev script: {scripts['dev']}")
+
+    # Create root package.json
+    root_pkg = {
+        "name": workspace_name,
+        "version": "0.0.0",
+        "private": True,
+        "type": "module",
+        "scripts": {
+            "dev": "slidev-workspace preview",
+            "build": "slidev-workspace build",
+        },
+        "devDependencies": {
+            "slidev-workspace": "latest",
+        },
+    }
+    (workspace_root / "package.json").write_text(json.dumps(root_pkg, indent=2) + "\n")
+    print("✏️  Created root package.json")
+
+    # Warn if slide uses pnpm catalog: versions
+    all_deps = {**pkg.get("dependencies", {}), **pkg.get("devDependencies", {})}
+    uses_catalog = any(v == "catalog:" for v in all_deps.values())
+
+    # Create pnpm-workspace.yaml
+    catalog_block = "\ncatalog:\n  # TODO: copy your catalog versions here\n  # '@slidev/cli': latest\n" if uses_catalog else ""
+    (workspace_root / "pnpm-workspace.yaml").write_text(
+        f"packages:\n  - 'slides/*'\n{catalog_block}"
+    )
+    print("✏️  Created pnpm-workspace.yaml")
+    if uses_catalog:
+        print("⚠️  pnpm catalog: versions detected — fill in the catalog: section in pnpm-workspace.yaml before running pnpm install")
+
+    # Create slidev-workspace.yaml
+    effective_base_url = base_url or f"/{workspace_name}"
+    config = f"""hero:
+  title: "Slide Collection"
+  description: "Browse all available slide decks"
+
+baseUrl: "{effective_base_url}"
+"""
+    (workspace_root / "slidev-workspace.yaml").write_text(config)
+    print("✏️  Created slidev-workspace.yaml")
+
+    print()
+    print(f"✅ Migration complete!")
+    print()
+    print(f"📂 Workspace structure:")
+    print(f"   {workspace_root.name}/")
+    print(f"   ├── slides/")
+    print(f"   │   └── {project_name}/")
+    print(f"   ├── package.json")
+    print(f"   ├── pnpm-workspace.yaml")
+    print(f"   └── slidev-workspace.yaml")
+    print()
+    print(f"🚀 Next steps:")
+    print(f"   cd {workspace_root}")
+    print(f"   pnpm install")
+    print(f"   pnpm dev")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Migrate a Slidev project to workspace")
+    parser.add_argument("--slides-dir", default=".", help="Path to the Slidev project")
+    parser.add_argument("--workspace-name", default=None, help="Name for the workspace root")
+    parser.add_argument("--base-url", default=None, help="baseUrl for slidev-workspace.yaml")
+    args = parser.parse_args()
+
+    slides_dir = Path(args.slides_dir)
+    workspace_name = args.workspace_name or f"{slides_dir.resolve().name}-workspace"
+
+    migrate(slides_dir, workspace_name, args.base_url)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/slidev-migrate/scripts/migrate.py
+++ b/.claude/skills/slidev-migrate/scripts/migrate.py
@@ -31,12 +31,23 @@ def detect_slidev_project(path: Path) -> bool:
 
 
 def already_workspace(path: Path) -> bool:
-    """Check if path is already a workspace root."""
-    return (path / "slidev-workspace.yaml").exists() or (path / "pnpm-workspace.yaml").exists()
+    """Check if path is already a workspace root with actual package globs."""
+    if (path / "slidev-workspace.yaml").exists():
+        return True
+    pnpm_ws = path / "pnpm-workspace.yaml"
+    if pnpm_ws.exists():
+        return "packages:" in pnpm_ws.read_text()
+    return False
 
 
 def migrate(slides_dir: Path, workspace_name: str, base_url: str):
     slides_dir = slides_dir.resolve()
+
+    if already_workspace(slides_dir):
+        print(f"❌ {slides_dir} is already a workspace root")
+        print("   (pnpm-workspace.yaml with packages: or slidev-workspace.yaml detected)")
+        print("   To add a new slide, place it in slides/<name>/ and update slidev-workspace.yaml manually.")
+        sys.exit(1)
 
     if not detect_slidev_project(slides_dir):
         print(f"❌ No Slidev project detected at {slides_dir}")

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ node_modules
 dist
 *.log
 .DS_Store
+*.skill
 
 _gh-pages

--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ The `useSlides` composable returns frontmatter data from all discovered presenta
 
 Get started in 5 minutes! See our [Quick Start Guide](https://leochiu-a.github.io/slidev-workspace/getting-started/quick-start.html).
 
+## Migrate from a Single Slidev Project
+
+Already have a single Slidev project and want to turn it into a workspace? Install the migration skill for [Claude Code](https://claude.ai/code):
+
+```bash
+npx skills add https://github.com/leochiu-a/slidev-workspace/tree/main/.claude/skills/slidev-migrate
+```
+
+Then ask Claude: **"migrate my slidev project to a workspace"** — it will scaffold the workspace structure, move your files, and configure everything automatically.
+
 ## Documentation
 
 - 📚 [Quick Start Guide](https://leochiu-a.github.io/slidev-workspace/getting-started/quick-start.html) - Get up and running in 5 minutes


### PR DESCRIPTION
## Summary

Adds a Claude Code skill (`slidev-migrate`) that automates converting a single Slidev project into a `slidev-workspace` multi-presentation structure. Users can install the skill via `npx skills add` and ask Claude to migrate their project — the bundled Python script handles validation, file layout, config generation, and edge cases automatically.

### Key Changes

- **`.claude/skills/slidev-migrate/SKILL.md`** — skill definition with automated/manual migration workflows, configuration reference, and caveats
- **`.claude/skills/slidev-migrate/scripts/migrate.py`** — Python script that validates the source project, copies files into `slides/<name>/`, rewrites the `--base` URL in the dev script, detects pnpm `catalog:` versions, and generates root `package.json`, `pnpm-workspace.yaml`, and `slidev-workspace.yaml`
- **`README.md`** — new "Migrate from a Single Slidev Project" section with install command
- **`.gitignore`** — excludes `*.skill` build artifacts

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] ♻️ Refactoring
- [ ] 🎨 Style/formatting changes
- [ ] 🧪 Test improvements
- [ ] 🔧 Configuration changes

## How It Works

1. Script detects a valid Slidev project (`slides.md` + `@slidev/cli` in `package.json`)
2. Guards against false-positive workspace detection — checks for `packages:` content in `pnpm-workspace.yaml`, not just file existence
3. Copies files into `slides/<project-name>/` (skipping `node_modules`, `dist`, `.git`)
4. Always overwrites the `dev` script's `--base` to match the destination folder name
5. Emits a `⚠️` warning and scaffolds a `catalog:` placeholder when pnpm catalog versions are detected
6. Generates workspace config files at the new root

## Test Plan

### Manual Testing

- [ ] Run `python3 .claude/skills/slidev-migrate/scripts/migrate.py --slides-dir <path>` against a real single Slidev project
- [ ] Verify generated workspace structure matches the before/after diagram in `SKILL.md`
- [ ] Confirm `dev` script is updated to `slidev --base /<folder-name>/`
- [ ] Test with a project that uses `catalog:` — confirm warning and placeholder appear
- [ ] Test against a directory that already has `pnpm-workspace.yaml` (without `packages:`) to verify it is NOT rejected as a false-positive workspace
- [ ] Run `pnpm install && pnpm dev` in the generated workspace

## Breaking Changes

None

## Checklist

- [x] 📝 Code follows style guidelines
- [x] 👀 Self-review performed
- [ ] 🧪 Tests added/updated
- [x] 📖 Documentation updated
